### PR TITLE
Added GradleBranchedCachePluginExtension.branchNameOverride

### DIFF
--- a/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/GradleBranchedCachePlugin.kt
+++ b/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/GradleBranchedCachePlugin.kt
@@ -1,6 +1,7 @@
 package io.github.k4k7us23.gradlebranchedcache
 
 import io.github.k4k7us23.gradlebranchedcache.vcs.BranchCacheKeyProvider
+import io.github.k4k7us23.gradlebranchedcache.vcs.BranchNameProvider
 import io.github.k4k7us23.gradlebranchedcache.vcs.GitVCS
 import org.gradle.api.Plugin
 import org.gradle.api.initialization.Settings
@@ -9,25 +10,29 @@ import java.net.URI
 
 class GradleBranchedCachePlugin : Plugin<Settings> {
 
-    private val branchKeyProvider = BranchCacheKeyProvider(
-        vcs = GitVCS()
-    )
-
     private lateinit var extension: GradleBranchedCachePluginExtension
 
     override fun apply(settings: Settings) {
         extension =
             settings.extensions.create("branchedRemoteBuildCache", GradleBranchedCachePluginExtension::class.java)
 
+        val branchCacheKeyProvider = BranchCacheKeyProvider(
+            branchNameProvider = BranchNameProvider(
+                vcs = GitVCS(),
+                extension = extension,
+            )
+        )
+
         settings.gradle.settingsEvaluated {
             settings.buildCache { buildCache ->
                 buildCache.remote(HttpBuildCache::class.java) { remote ->
-                    remote.url = getFinalRemoteUrl()
+                    remote.url = getFinalRemoteUrl(branchCacheKeyProvider)
                     extension.push?.let(remote::setPush)
 
                     extension.enabled?.let(remote::setEnabled)
                     extension.allowUntrustedServer?.let(remote::setAllowUntrustedServer)
                     extension.allowInsecureProtocol?.let(remote::setAllowInsecureProtocol)
+                    extension.useExpectContinue?.let(remote::setUseExpectContinue)
 
                     extension.credentials.let { extensionCredentials ->
                         val remoteCredentials = remote.credentials
@@ -41,9 +46,9 @@ class GradleBranchedCachePlugin : Plugin<Settings> {
 
     // TODO check base url is not empty
     // TODO support no slash at the end
-    private fun getFinalRemoteUrl(): URI {
+    private fun getFinalRemoteUrl(branchCacheKeyProvider: BranchCacheKeyProvider): URI {
         val baseUrl = URI(requireNotNull(extension.baseUrl))
-        return baseUrl.resolve(branchKeyProvider.getKey())
+        return baseUrl.resolve(branchCacheKeyProvider.getKey())
     }
 
 }

--- a/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/GradleBranchedCachePluginExtension.kt
+++ b/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/GradleBranchedCachePluginExtension.kt
@@ -15,6 +15,8 @@ open class GradleBranchedCachePluginExtension {
 
     val credentials: HttpBuildCacheCredentials = HttpBuildCacheCredentials()
 
+    var branchNameOverride: String? = null
+
     fun credentials(action: Action<HttpBuildCacheCredentials>) {
         action.execute(credentials)
     }

--- a/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/vcs/BranchCacheKeyProvider.kt
+++ b/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/vcs/BranchCacheKeyProvider.kt
@@ -3,12 +3,12 @@ package io.github.k4k7us23.gradlebranchedcache.vcs
 import java.security.MessageDigest
 
 class BranchCacheKeyProvider(
-    private val vcs: IVCS
+    private val branchNameProvider: BranchNameProvider
 ) {
 
     // TODO: implement unit-test
     fun getKey(): String {
-        return sha1(vcs.getBranch())
+        return sha1(branchNameProvider.getBranchName())
     }
 
     private fun sha1(input: String): String {

--- a/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/vcs/BranchNameProvider.kt
+++ b/plugin/src/main/kotlin/io/github/k4k7us23/gradlebranchedcache/vcs/BranchNameProvider.kt
@@ -1,0 +1,18 @@
+package io.github.k4k7us23.gradlebranchedcache.vcs
+
+import io.github.k4k7us23.gradlebranchedcache.GradleBranchedCachePluginExtension
+
+class BranchNameProvider(
+    private val vcs: IVCS,
+    private val extension: GradleBranchedCachePluginExtension,
+) {
+
+    fun getBranchName(): String {
+        val extensionBranchName = extension.branchNameOverride
+        return if (extensionBranchName == null) {
+            vcs.getBranch()
+        } else {
+            extensionBranchName
+        }
+    }
+}


### PR DESCRIPTION
- This MR resolves issue https://github.com/k4k7us23/Gradle-Branched-Cache/issues/6
- A new branchNameOverride property was added to GradleBranchedCachePluginExtension, which will override branch name from git, in case if provided